### PR TITLE
Allow validation of TLS certificates for FlashArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ API token and the Pure endpoint (**for pure-fa-exporter only**) have been tweake
 - APITOKEN
 - FA_ENDPOINT
 
+Additionally, the `CACERTPATH` environment variable may be set to the path of a CA certificate or bundle to use for SSL verification. If set, the exporter will use this for all requests. Otherwise, verification will be disabled.
+
 ### Building and Deploying
 
 The exporter is preferably built and launched via Docker. You can also scale the exporter deployment to multiple containers on Kubernetes thanks to the stateless nature of the application.

--- a/extra/pure-helper/pure_helper.py
+++ b/extra/pure-helper/pure_helper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from flask import Flask, request, abort, make_response, jsonify
+import os
 import urllib3
 import purestorage
 
@@ -101,12 +102,16 @@ def route_error_500(error):
 
 
 def list_volume_connections(target, api_token, volume):
-    # disable ceritificate warnings
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    # Check for the path of a certificate bundle to use for SSL verification
+    cert_path = os.getenv('CACERTPATH')
+    if not cert_path:
+        # disable ceritificate warnings as we will default to insecure
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     conn = purestorage.FlashArray(
             target,
             api_token=api_token,
-            user_agent='Purity_FA_Prometheus_exporter/1.0')
+            user_agent='Purity_FA_Prometheus_exporter/1.0',
+            request_kwargs={"verify": cert_path} if cert_path else None)
     array = conn.get()
     p_hosts = conn.list_volume_private_connections(volume)
     s_hosts = conn.list_volume_shared_connections(volume)
@@ -125,12 +130,16 @@ def list_volume_connections(target, api_token, volume):
     return vol
 
 def list_host_connections(target, api_token, host):
-    # disable ceritificate warnings
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    # Check for the path of a certificate bundle to use for SSL verification
+    cert_path = os.getenv('CACERTPATH')
+    if not cert_path:
+        # disable ceritificate warnings as we will default to insecure
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     conn = purestorage.FlashArray(
             target,
             api_token=api_token,
-            user_agent='Purity_FA_Prometheus_exporter/1.0')
+            user_agent='Purity_FA_Prometheus_exporter/1.0',
+            request_kwargs={"verify": cert_path} if cert_path else None)
     array = conn.get()
     v_list = conn.list_host_connections(host)
     vols = []

--- a/flasharray_collector/flasharray_metrics/flasharray.py
+++ b/flasharray_collector/flasharray_metrics/flasharray.py
@@ -1,10 +1,14 @@
+import os
 import re
 import urllib3
 import purestorage
 
 
-# disable ceritificate warnings
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+# Check for the path of a certificate bundle to use for SSL verification
+cert_path = os.getenv('CACERTPATH')
+if not cert_path:
+    # disable ceritificate warnings as we will default to insecure
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 PURE_NAA = 'naa.624a9370'
 
@@ -34,7 +38,8 @@ class FlashArray:
             self.flasharray =  purestorage.FlashArray(
                 endpoint,
                 api_token=api_token,
-                user_agent='Purity_FA_Prometheus_exporter/1.0')
+                user_agent='Purity_FA_Prometheus_exporter/1.0',
+                request_kwargs={"verify": cert_path} if cert_path else None)
         except purestorage.PureError:
             pass
 


### PR DESCRIPTION
Add detection of an additional environment variable which may be used to provide a path to a CA cert bundle against which to perform TLS certificate validation for FlashArray.

If set, the path specified is passed through for use during TLS validation, which will now be performed. If left unset, then the existing default behaviour of disabling warnings and not doing validation will remain.