### PR TITLE
Fix bug when getting stats for old NIC names

### DIFF
--- a/flasharray_collector/flasharray_metrics/flasharray.py
+++ b/flasharray_collector/flasharray_metrics/flasharray.py
@@ -187,7 +187,7 @@ class FlashArray:
             try:
                 for n in self.flasharray.list_network_interfaces(**params):
                     nicdict[n['name']].update(n)
-            except purestorage.PureError:
+            except (purestorage.PureError, KeyError):
                 pass
         self.network_interfaces = nicdict
         return list(self.network_interfaces.values())

--- a/flasharray_collector/flasharray_metrics/flasharray.py
+++ b/flasharray_collector/flasharray_metrics/flasharray.py
@@ -186,8 +186,11 @@ class FlashArray:
         for params in nic_kpi_params:
             try:
                 for n in self.flasharray.list_network_interfaces(**params):
-                    nicdict[n['name']].update(n)
-            except (purestorage.PureError, KeyError):
+                    try:
+                        nicdict[n['name']].update(n)
+                    except KeyError:
+                        pass
+            except purestorage.PureError:
                 pass
         self.network_interfaces = nicdict
         return list(self.network_interfaces.values())

--- a/flasharray_collector/flasharray_metrics/flasharray.py
+++ b/flasharray_collector/flasharray_metrics/flasharray.py
@@ -189,6 +189,8 @@ class FlashArray:
                     try:
                         nicdict[n['name']].update(n)
                     except KeyError:
+                        # We got stats for a NIC that is not in the current list.
+                        # This may be due to old/changed NIC configuration, so ignore it.
                         pass
             except purestorage.PureError:
                 pass


### PR DESCRIPTION
Code from the original repo to get NIC stats from the array has a bug - it seems that stats are returned for all NICs which may include old names which aren't in the current NIC list, leading to a key error when attempting to associate these stats with a current NIC.

As a simple fix, also catch and ignore these errors when attempting to get these stats.